### PR TITLE
Update Druid url

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 members = ["match-derive", "match-macro"]
 
 [dependencies]
-druid = { git = "https://github.com/xi-editor/druid" }
+druid = { git = "https://github.com/linebender/druid.git" }
 
 [dependencies.match-derive]
 path = "match-derive"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Druid enum helpers
 
-In this repo I work on implementing the ideas mentioned in [druid#789](https://github.com/xi-editor/druid/issues/789)
+In this repo I work on implementing the ideas mentioned in [druid#789](https://github.com/linebender/druid/issues/789)
 
 The two sub-crates implement the macros while the main crate is the testing ground.
 

--- a/match-macro/Cargo.toml
+++ b/match-macro/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 proc-macro-hack = "0.5.15"
-druid = { git = "https://github.com/xi-editor/druid" }
+druid = { git = "https://github.com/linebender/druid.git" }
 
 [dependencies.match-macro-impl]
 path = "../match-macro-impl"


### PR DESCRIPTION
The Druid GitHub repo has changed owners, which caused the url to change. This would cause Cargo to not be able to find the repository when building.